### PR TITLE
update net.minidev:json-smart to 2.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
 
     <commons-lang.version>2.6</commons-lang.version>
-    <json-smart.version>1.3.2</json-smart.version>
+    <json-smart.version>2.4.7</json-smart.version>
     <kafka.version>2.8.0</kafka.version>
     <log4j-jboss-logmanager.version>1.2.2.Final</log4j-jboss-logmanager.version>
     <quarkus.version>2.2.1.Final</quarkus.version>


### PR DESCRIPTION
This dependency has to be upgraded for all testing with Wiremock due to clashing dependencies. Older version will make Wiremock unusable but newer version of this dependency in the logging-plugin should be harmless as it is using just basic functionality of this dependency.

context: https://github.com/project-ncl/repository-driver/pull/12