### PR TITLE
 [NCL-7142] Allow user to specify sasl login option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 target/
 .classpath
 .project
+
+.idea
+*.iml

--- a/runtime/src/main/java/org/jboss/pnc/logging/kafka/KafkaLogConfig.java
+++ b/runtime/src/main/java/org/jboss/pnc/logging/kafka/KafkaLogConfig.java
@@ -93,6 +93,18 @@ public class KafkaLogConfig {
     public Optional<String> clientJaasConfPath;
 
     /**
+     * Provide the client Jaas SASL login details via a string
+     */
+    @ConfigItem
+    public Optional<String> clientJaasConf;
+
+    /**
+     * Allow user to specify SASL mechanism for authentication to Kafka.
+     */
+    @ConfigItem
+    public Optional<String> saslMechanism;
+
+    /**
      * KafkaLog4jAppender's {@link KafkaLog4jAppender#getKerb5ConfPath() kerb5ConfPath}.
      */
     @ConfigItem
@@ -171,7 +183,8 @@ public class KafkaLogConfig {
                 + ", sslTruststoreLocation=" + sslTruststoreLocation + ", sslTruststorePassword="
                 + sslTruststorePassword + ", sslKeystoreType=" + sslKeystoreType + ", sslKeystoreLocation="
                 + sslKeystoreLocation + ", sslKeystorePassword=" + sslKeystorePassword + ", saslKerberosServiceName="
-                + saslKerberosServiceName + ", clientJaasConfPath=" + clientJaasConfPath + ", kerb5ConfPath="
+                + saslKerberosServiceName + ", clientJaasConfPath=" + clientJaasConfPath
+                + ", clientJaasConf=" + clientJaasConf + ", saslMechanism=" + saslMechanism + ", kerb5ConfPath="
                 + kerb5ConfPath + ", maxBlockMs=" + maxBlockMs + ", retries=" + retries + ", requiredNumAcks="
                 + requiredNumAcks + ", deliveryTimeoutMs=" + deliveryTimeoutMs + ", ignoreExceptions="
                 + ignoreExceptions + ", syncSend=" + syncSend + ", level=" + level + ", async=" + async

--- a/runtime/src/main/java/org/jboss/pnc/logging/kafka/KafkaLogHandlerRecorder.java
+++ b/runtime/src/main/java/org/jboss/pnc/logging/kafka/KafkaLogHandlerRecorder.java
@@ -107,6 +107,8 @@ public class KafkaLogHandlerRecorder {
         config.sslKeystorePassword.ifPresent(password -> appender.setSslKeystorePassword(password));
         config.saslKerberosServiceName.ifPresent(name -> appender.setSaslKerberosServiceName(name));
         config.clientJaasConfPath.ifPresent(path -> appender.setClientJaasConfPath(path));
+        config.clientJaasConf.ifPresent(clientJaasConf -> appender.setClientJaasConf(clientJaasConf));
+        config.saslMechanism.ifPresent(saslMechanism -> appender.setSaslMechanism(saslMechanism));
         config.kerb5ConfPath.ifPresent(path -> appender.setKerb5ConfPath(path));
         config.maxBlockMs.ifPresent(maxBlockMs -> appender.setMaxBlockMs(maxBlockMs));
 


### PR DESCRIPTION
The 2 new configs that the user can specify are:

- `saslMechanism`
- `clientJaasConf`

They are then sent to the `KafkaLog4jAppender` for more configuration.
These 2 configs specify the authentication option when talking with
Kafka.

See: https://docs.confluent.io/platform/current/kafka/authentication_sasl/authentication_sasl_plain.html for examples.