### PR TITLE
[NCLSUP-784] Do not crash app if handler broken

### DIFF
--- a/runtime/src/main/java/org/jboss/pnc/logging/kafka/KafkaLogHandlerRecorder.java
+++ b/runtime/src/main/java/org/jboss/pnc/logging/kafka/KafkaLogHandlerRecorder.java
@@ -42,7 +42,17 @@ public class KafkaLogHandlerRecorder {
             return new RuntimeValue<>(Optional.empty());
         }
 
-        KafkaLog4jAppender appender = createAppender(config);
+        KafkaLog4jAppender appender;
+        try {
+            appender = createAppender(config);
+        } catch (RuntimeException e) {
+            System.err.println("[ERROR] Couldn't start kafka-logging due to Kafka server issues");
+            e.printStackTrace();
+            // If the Kafka appender cannot be created due to Kafka server issues, catch the exception and just consider
+            // the handler as not enabled. A restart of the application is required to switch on the kafka log handler
+            // once the Kafka server has recovered
+            return new RuntimeValue<>(Optional.empty());
+        }
 
         Log4jAppenderHandler kafkaHandler = new Log4jAppenderHandler(appender, false);
 


### PR DESCRIPTION
There are some scenarios where we might not be able to create a `KafkaLog4jAppender` object, one of them because the Kafka server we want to send the data is down.

In those scenarios, the initialization of the handler fails and Quarkus applications using the handler won't be able to start.

```
ERROR: Failed to start application (with profile prod)
org.apache.kafka.common.config.ConfigException: No resolvable bootstrap urls given in bootstrap.servers
	at org.apache.kafka.clients.ClientUtils.parseAndValidateAddresses(ClientUtils.java:89)
	at org.apache.kafka.clients.ClientUtils.parseAndValidateAddresses(ClientUtils.java:48)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:416)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:292)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:319)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:304)
	at org.apache.kafka.log4jappender.KafkaLog4jAppender.getKafkaProducer(KafkaLog4jAppender.java:341)
	at org.apache.kafka.log4jappender.KafkaLog4jAppender.activateOptions(KafkaLog4jAppender.java:335)
	at org.jboss.pnc.logging.kafka.KafkaLogHandlerRecorder.createAppender(KafkaLogHandlerRecorder.java:122)
```

This commit is an attempt to implement the behaviour of not crashing the application in case the Kafka server is down. It does so by just disabling the handler on those errors.

Unfortunately, that means that the application will have to be restarted to send logs again to the Kafka server once the latter has recovered.

There is an error log printed in stderr and the stacktrace nature of the error is also printed in stderr to let the user know that the kafka handler isn't working, and the reason why.