### PR TITLE
[NCL-7802] Migrate to commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
 
-    <commons-lang.version>2.6</commons-lang.version>
+    <commons-lang3.version>3.11</commons-lang3.version>
     <json-smart.version>2.4.10</json-smart.version>
     <kafka.version>3.4.0</kafka.version>
     <log4j-jboss-logmanager.version>1.3.0.Final</log4j-jboss-logmanager.version>
@@ -95,9 +95,9 @@
         <version>${kafka.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>${commons-lang.version}</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
       </dependency>
       <dependency>
         <groupId>net.minidev</groupId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -43,8 +43,8 @@
       </exclusions>
     </dependency>
     <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>net.minidev</groupId>

--- a/runtime/src/main/java/org/jboss/pnc/logging/kafka/DefaultFormatterOrLayoutProducer.java
+++ b/runtime/src/main/java/org/jboss/pnc/logging/kafka/DefaultFormatterOrLayoutProducer.java
@@ -1,6 +1,6 @@
 package org.jboss.pnc.logging.kafka;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Layout;
 import org.jboss.logmanager.formatters.JsonFormatter;
 import org.jboss.logmanager.formatters.StructuredFormatter.Key;

--- a/runtime/src/main/java/org/jboss/pnc/logging/kafka/PncLoggingLayout.java
+++ b/runtime/src/main/java/org/jboss/pnc/logging/kafka/PncLoggingLayout.java
@@ -1,8 +1,8 @@
 package org.jboss.pnc.logging.kafka;
 
 import net.minidev.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.time.FastDateFormat;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.log4j.Layout;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.ThrowableInformation;


### PR DESCRIPTION
The way of computing the buffer size for allocation of StrBuilder in StringUtils.join was causing OOM error with commons-lang 2.6 and heap size restricted to 500 MiB. It seems to be re-implemented in a more reasonable way in commons-lang3.